### PR TITLE
Fixing incorrect package add script commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Generate react-native pickers with range numbers.
 Add the package to your project
 
 ```bash
-yarn add react-native-number-please
+yarn add digicard-react-native-number-please
 
-npm install -S react-native-number-please
+npm install -S digicard-react-native-number-please
 ```
 
 ## Usage


### PR DESCRIPTION
It's pretty confusing that there are now two packages where the fork is maintaining the original but the original is not being updated on npm.